### PR TITLE
Add tests that will fail 🍐

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Get a useful signal out of tests, minimize the noise
 
 * [Manning Twitch stream Feb 23, 2022](https://www.twitch.tv/manningpublications/schedule?seriesID=7f6bd1c8-5c6e-4e74-8dac-6faa55730700)
-* [Slides](https://docs.google.com/presentation/d/1TffyautuQJXdeEhgYKYYICgh6nhfBvvWosV9WPrgDwI/edit#slide=id.g116f8da5611_0_44)
+* [Slides](https://docs.google.com/presentation/d/1TffyautuQJXdeEhgYKYYICgh6nhfBvvWosV9WPrgDwI)
 
 Learn the difference between signal and noise when it comes to tests - it might not be what you expect!
 We'll walk through some examples of noisy passing tests, and noisy flakey tests, and talk about why
@@ -12,14 +12,17 @@ retrying flakey tests will actually increase the noise in your tests.
 1. [Define signal versus noise](https://docs.google.com/presentation/d/1TffyautuQJXdeEhgYKYYICgh6nhfBvvWosV9WPrgDwI/edit#slide=id.g116f8da5611_0_1)
 1. [Describe how to handle test noise](https://docs.google.com/presentation/d/1TffyautuQJXdeEhgYKYYICgh6nhfBvvWosV9WPrgDwI/edit#slide=id.g116f8da5611_0_44)
 1. Show examples of passing tests:
-    1. Test that passes (success + signal)
-    1. Test that passes but shouldn’t (success but should fail) (`test_get_most_recent`)
+    1. Test that passes (success + signal) `test_add_item_multiple`
+    1. Test that passes but shouldn’t (success but should fail) `test_get_most_recent`
 1. Fix the test that passes but shouldn't
 1. Show examples of failing tests:
-    1. Failure that provides new information
-    1. Failure that doesn’t provide new information
+    1. Failure that provides new information `test_submit_orders` (logic broken), `test_get_total_orders` (test broken)
+    1. Failure that doesn’t provide new information (tests that are left broken, flakes)
 1. Fix the failing tests
 1. [Describe flakey tests](https://docs.google.com/presentation/d/1TffyautuQJXdeEhgYKYYICgh6nhfBvvWosV9WPrgDwI/edit#slide=id.g116f8da5611_0_34)
-1. Show example of a flakey test
+1. Show example of a flakey test `test_process_order`
 1. Fix the flakey test
+    1. Using retry on the entire function `@retry.retry(retries=3)`
+    1. Using retry on the connect function only `retry_network_errors(mrf.connect, retries=3)`
+    1. Update the connect function itself to backoff and retry (using [backoff lib](https://pypi.org/project/backoff/))
 1. If extra time: explore some real life flakey tests

--- a/icecream.py
+++ b/icecream.py
@@ -8,14 +8,23 @@ class NetworkException(Exception):
 
 class Orders:
     def __init__(self):
+        self.totalOrders = 0
         self.orders = collections.defaultdict(list)
 
     def add(self, date, order):
+        self.totalOrders += 1
         self.orders[date].append(order)
 
     def get_most_recent(self):
         most_recent_key = list(self.orders)[-1]
         return self.orders[most_recent_key][0]
+
+    def get_total_orders(self):
+        return self.totalOrders
+
+    def submit_orders(self, service):
+        for _, order in self.orders.items():
+            service.process_order(order)
 
 
 class MrFreezie():
@@ -25,4 +34,5 @@ class MrFreezie():
         pass
 
     def process_order(self, order):
+        # pretend some cool order processing is happening here
         return []

--- a/icecream_test.py
+++ b/icecream_test.py
@@ -5,30 +5,60 @@ import unittest
 import icecream
 
 
+class IceCreamProviderFake():
+    def connect(self):
+        # no flakey connection here
+        pass
+
+    def process_order(self, order):
+        # pretend some cool order processing is happening here
+        return []
+
+
+def _get_seeded_orders():
+    orders = icecream.Orders()
+    orders.add(datetime.date(2020, 9, 4), "swirl cone")
+    orders.add(datetime.date(2020, 9, 7), "cherry glazed")
+    orders.add(datetime.date(2020, 9, 10), "rainbow sprinkle")
+    return orders
+
+
 class TestOrder(unittest.TestCase):
 
-    def test_add_item(self):
+    def test_add_item_multiple(self):
         '''This test passes and should'''
-        orders = icecream.Orders()
-        orders.add(datetime.date(2020, 9, 4), "swirl cone")
-        orders.add(datetime.date(2020, 9, 7), "cherry glazed")
+        orders = _get_seeded_orders()
 
         expectedOrders = collections.defaultdict(list, {
             datetime.date(2020, 9, 7): ["cherry glazed"],
             datetime.date(2020, 9, 4): ["swirl cone"],
+            datetime.date(2020, 9, 10): ["rainbow sprinkle"],
         })
 
         self.assertDictEqual(orders.orders, expectedOrders)
 
     def test_get_most_recent(self):
         '''This test passes, but shouldn't'''
-        orders = icecream.Orders()
-        orders.add(datetime.date(2020, 9, 4), "swirl cone")
-        orders.add(datetime.date(2020, 9, 7), "cherry glazed")
-        orders.add(datetime.date(2020, 9, 10), "rainbow sprinkle")
-
+        orders = _get_seeded_orders()
         most_recent = orders.get_most_recent()
         self.assertEqual(most_recent, "rainbow sprinkle")
+
+    @unittest.skip("This test will fail - on purpose!")
+    def test_submit_orders(self):
+        '''This test will fail because the logic is broken'''
+        orders = _get_seeded_orders()
+
+        provider = IceCreamProviderFake()
+        provider.connect()
+
+        orders.submit_orders(provider)
+        self.assertEqual(len(orders.orders), 0)
+
+    @unittest.skip("This test will fail - on purpose!")
+    def test_get_total_orders(self):
+        '''This test will fail b/c the test is broken'''
+        orders = _get_seeded_orders()
+        self.assertEqual(orders.get_total_orders(), 0)
 
 
 def _generate_mr_freezie_order():
@@ -50,6 +80,7 @@ class TestMrFreezie(unittest.TestCase):
         mrf.connect()
         mrf.process_order(order)
         _assert_order_updated(order)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add two tests, currently skipped, which can demonstrate test noise from
failing tests. One fails b/c the underlying logic is broken (i.e. a bug)
and the other fails b/c of a problem with the test itself.